### PR TITLE
Fix: Use docstrings in python ports

### DIFF
--- a/spectralevents_functions.py
+++ b/spectralevents_functions.py
@@ -192,7 +192,7 @@ def energyvec(f,s,Fs,width):
 
 def morlet(f,t,width):
     '''
-    'Morlet's wavelet for frequency f and time t. 
+    Morlet's wavelet for frequency f and time t. 
     The wavelet will be normalized so the total energy is 1.
     width defines the ``width'' of the wavelet. 
     A value >= 5 is suggested.

--- a/test.py
+++ b/test.py
@@ -1,3 +1,16 @@
+'''
+Translation of spectral events code to python
+
+  By: Tim Bardouille, 2019
+      Dalhousie University, Halifax, NS, Canada
+      tim.bardouille@dal.ca
+
+Top-level run script for finding spectral events in test data 
+provided by original SpectralEvents GitHub repo.
+
+  Note: only method 1 for finding events is implemented
+'''
+
 import os, sys
 import numpy as np
 import scipy.io as io
@@ -9,18 +22,6 @@ import pandas as pd
 import matplotlib.pyplot as plt
 
 
-#################################################
-# Translation of spectral events code to python
-#
-#   By: Tim Bardouille, 2019
-#       Dalhousie University, Halifax, NS, Canada
-#       tim.bardouille@dal.ca
-#
-# Top-level run script for finding spectral events in test data 
-# provided by original SpectralEvents GitHub repo.
-#
-#   Note: only method 1 for finding events is implemented
-#
 
 ####################################################################
 # Main Code


### PR DESCRIPTION
*Python files only*: Converted the commented function descriptions (which work as help text in Matlab) into proper docstrings so that, e.g. ipython's `help()` will do the right thing. Did not edit any of the text, so it is still not in a consistent or standard format.

Made no changes to code.
